### PR TITLE
Add javax annotation dependency

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,32 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  mvn_options: -B -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java-version: [ 8, 11, 17, 18 ]
+        runs-on: [ ubuntu-latest, macos-latest, windows-latest ]
+    name: Build on ${{ matrix.runs-on }} with jdk ${{ matrix.java-version }}
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: ./mvnw $mvn_options package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@ under the License.
 		<maven.compiler.source>${target.java.version}</maven.compiler.source>
 		<maven.compiler.target>${target.java.version}</maven.compiler.target>
 
+		<annotation-api.version>1.3.2</annotation-api.version>
 		<flink.version>1.15-SNAPSHOT</flink.version>
 		<log4j.version>2.17.2</log4j.version>
 		<datafaker.version>1.2.0</datafaker.version>
@@ -129,6 +130,12 @@ under the License.
 			<artifactId>lombok</artifactId>
 			<version>${lombok.version}</version>
 			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>${annotation-api.version}</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
The PR adds dependency on `javax.annotation-api` to make it compilable with jdk11+ and adds GitHub actions to build with different jdk versions on Win, Mac, Linux

An example of how it could look like https://github.com/snuyanzin/flink-example/actions/runs/2115568400